### PR TITLE
Run slack:deploy:starting after deploy:starting instead of before

### DIFF
--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -59,9 +59,9 @@ namespace :slack do
   end
 end
 
-before 'deploy:starting', 'slack:deploy:starting'
-after  'deploy:finished', 'slack:deploy:finished'
-after  'deploy:failed',   'slack:deploy:failed'
+after 'deploy:starting', 'slack:deploy:starting'
+after 'deploy:finished', 'slack:deploy:finished'
+after 'deploy:failed',   'slack:deploy:failed'
 
 namespace :load do
   task :defaults do

--- a/spec/tasks_spec.rb
+++ b/spec/tasks_spec.rb
@@ -5,8 +5,10 @@ describe Slackistrano do
     Rake::Task['load:defaults'].invoke
   end
 
-  it "invokes slack:deploy:starting before deploy:starting" do
-    expect(Rake::Task['deploy:starting'].prerequisites).to include 'slack:deploy:starting'
+  it "invokes slack:deploy:starting after deploy:starting" do
+    set :slack_run_starting, ->{ true }
+    expect(Slackistrano).to receive :post
+    Rake::Task['deploy:starting'].execute
   end
 
   it "invokes slack:deploy:finished after deploy:finished" do


### PR DESCRIPTION
so that variables set during the starting phase with `ask` calls can be included in the starting message.

We needed this since some of our stages use `ask :branch` to get the git branch that should be deployed, which we wanted to be included in the deploy starting message in Slack. Without this change, trying to `fetch :branch` in the starting message would result in text like `#Proc:0x007f33427b0670@config/deploy/staging.rb:15>` (while it would appear fine in the finished and failure messages, since the branch had been provided by that point).

Despite the slight delay in when the starting message appears, I think this change is actually the desirable default behavior, since you probably don't want to broadcast a deploy is starting until any necessary variables have been `ask`ed for. An alternative could be to make it an option, which I didn't tackle here.
