### PR TITLE
Include rake to avoid rails server to crash on bootstrap + move triggers from code to deploy.rb of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,16 @@ Optionally, override the other slack settings:
     set :slack_icon_emoji,   ->{ nil } # will override icon_url, Must be a string (ex: ':shipit:')
     set :slack_channel,      ->{ '#general' }
     set :slack_username,     ->{ 'Slackistrano' }
-    set :slack_run_starting, ->{ true }
-    set :slack_run_finished, ->{ true }
-    set :slack_run_failed,   ->{ true }
     set :slack_msg_starting, ->{ "#{ENV['USER'] || ENV['USERNAME']} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}." }
     set :slack_msg_finished, ->{ "#{ENV['USER'] || ENV['USERNAME']} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}." }
     set :slack_msg_failed,   ->{ "*ERROR!* #{ENV['USER'] || ENV['USERNAME']} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}." }
     set :slack_via_slackbot, ->{ false } # Set to true to send the message via slackbot instead of webhook
+
+Add inside you deploy.rb the hook you want to add to notify Slack
+
+    after 'deploy:starting', 'slack:deploy:starting'
+    after 'deploy:finished', 'slack:deploy:finished'
+    after 'deploy:failed',   'slack:deploy:failed'
 
 **Note**: You may wish to disable one of the notifications if another service (ex:
 Honeybadger) also displays a deploy notification.

--- a/lib/slackistrano.rb
+++ b/lib/slackistrano.rb
@@ -1,3 +1,4 @@
+require 'rake'
 require 'slackistrano/version'
 require 'net/http'
 require 'json'

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -1,70 +1,59 @@
-
 namespace :slack do
   namespace :deploy do
 
     task :starting do
-      if fetch(:slack_run_starting)
-        run_locally do
-          Slackistrano.post(
-            team: fetch(:slack_team),
-            token: fetch(:slack_token),
-            via_slackbot: fetch(:slack_via_slackbot),
-            payload: {
-              channel: fetch(:slack_channel),
-              username: fetch(:slack_username),
-              icon_url: fetch(:slack_icon_url),
-              icon_emoji: fetch(:slack_icon_emoji),
-              text: fetch(:slack_msg_starting)
-            }
-          )
-        end
+      run_locally do
+        Slackistrano.post(
+          team: fetch(:slack_team),
+          token: fetch(:slack_token),
+          via_slackbot: fetch(:slack_via_slackbot),
+          payload: {
+            channel: fetch(:slack_channel),
+            username: fetch(:slack_username),
+            icon_url: fetch(:slack_icon_url),
+            icon_emoji: fetch(:slack_icon_emoji),
+            text: fetch(:slack_msg_starting)
+          }
+        )
       end
     end
 
     task :finished do
-      if fetch(:slack_run_finished)
-        run_locally do
-          Slackistrano.post(
-            team: fetch(:slack_team),
-            token: fetch(:slack_token),
-            via_slackbot: fetch(:slack_via_slackbot),
-            payload: {
-              channel: fetch(:slack_channel),
-              username: fetch(:slack_username),
-              icon_url: fetch(:slack_icon_url),
-              icon_emoji: fetch(:slack_icon_emoji),
-              text: fetch(:slack_msg_finished)
-            }
-          )
-        end
+      run_locally do
+        Slackistrano.post(
+          team: fetch(:slack_team),
+          token: fetch(:slack_token),
+          via_slackbot: fetch(:slack_via_slackbot),
+          payload: {
+            channel: fetch(:slack_channel),
+            username: fetch(:slack_username),
+            icon_url: fetch(:slack_icon_url),
+            icon_emoji: fetch(:slack_icon_emoji),
+            text: fetch(:slack_msg_finished)
+          }
+        )
       end
     end
 
     task :failed do
-      if fetch(:slack_run_failed)
-        run_locally do
-          Slackistrano.post(
-            team: fetch(:slack_team),
-            token: fetch(:slack_token),
-            via_slackbot: fetch(:slack_via_slackbot),
-            payload: {
-              channel: fetch(:slack_channel),
-              username: fetch(:slack_username),
-              icon_url: fetch(:slack_icon_url),
-              icon_emoji: fetch(:slack_icon_emoji),
-              text: fetch(:slack_msg_failed),
-            }
-          )
-        end
+      run_locally do
+        Slackistrano.post(
+          team: fetch(:slack_team),
+          token: fetch(:slack_token),
+          via_slackbot: fetch(:slack_via_slackbot),
+          payload: {
+            channel: fetch(:slack_channel),
+            username: fetch(:slack_username),
+            icon_url: fetch(:slack_icon_url),
+            icon_emoji: fetch(:slack_icon_emoji),
+            text: fetch(:slack_msg_failed),
+          }
+        )
       end
     end
 
   end
 end
-
-after 'deploy:starting', 'slack:deploy:starting'
-after 'deploy:finished', 'slack:deploy:finished'
-after 'deploy:failed',   'slack:deploy:failed'
 
 namespace :load do
   task :defaults do
@@ -74,9 +63,6 @@ namespace :load do
     set :slack_icon_url,     ->{ 'http://gravatar.com/avatar/885e1c523b7975c4003de162d8ee8fee?r=g&s=40' }
     set :slack_icon_emoji,   ->{ nil } # Emoji to use. Overrides icon_url. Must be a string (ex: ':shipit:')
     set :slack_username,     ->{ 'Slackistrano' }
-    set :slack_run_starting, ->{ true } # Set to false to disable starting message.
-    set :slack_run_finished, ->{ true } # Set to false to disable finished message.
-    set :slack_run_failed,   ->{ true } # Set to false to disable failure message.
     set :slack_msg_starting, ->{ "#{ENV['USER'] || ENV['USERNAME']} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}." }
     set :slack_msg_finished, ->{ "#{ENV['USER'] || ENV['USERNAME']} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}." }
     set :slack_msg_failed,   ->{ "*ERROR!* #{ENV['USER'] || ENV['USERNAME']} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}." }

--- a/spec/tasks_spec.rb
+++ b/spec/tasks_spec.rb
@@ -5,35 +5,11 @@ describe Slackistrano do
     Rake::Task['load:defaults'].invoke
   end
 
-  it "invokes slack:deploy:starting after deploy:starting" do
-    set :slack_run_starting, ->{ true }
-    expect(Slackistrano).to receive :post
-    Rake::Task['deploy:starting'].execute
-  end
-
-  it "invokes slack:deploy:finished after deploy:finished" do
-    set :slack_run_finished, ->{ true }
-    expect(Slackistrano).to receive :post
-    Rake::Task['deploy:finished'].execute
-  end
-
-  it "invokes slack:deploy:failed after deploy:failed" do
-    set :slack_run_failed, ->{ true }
-    expect(Slackistrano).to receive :post
-    Rake::Task['deploy:failed'].execute
-  end
-
   %w[starting finished failed].each do |stage|
 
     it "posts to slack on slack:deploy:#{stage}" do
       set "slack_run_#{stage}".to_sym, ->{ true }
       expect(Slackistrano).to receive :post
-      Rake::Task["slack:deploy:#{stage}"].execute
-    end
-
-    it "does not post to slack on slack:deploy:#{stage} when disabled" do
-      set "slack_run_#{stage}".to_sym, ->{ false }
-      expect(Slackistrano).not_to receive :post
       Rake::Task["slack:deploy:#{stage}"].execute
     end
 


### PR DESCRIPTION
I had problem starting my server with the current implementation.

`lib/slackistrano/tasks/slack.rake:2:in `<top (required)>': undefined method `namespace' for main:Object (NoMethodError)`

It apprends that `require 'rake'` was needed.

But then the hooks `after 'deploy:starting', 'slack:deploy:starting'` were not accepted anymore:

`<top (required)>': undefined method after' for main:Object (NoMethodError)`

So I decided to removed the trigger from the configuration  `set :slack_run_starting, ->{ true }` and propose to had the hooks manually inside the deploy.rb like the other gems are doing.

It works fine for me, so I propose the pull request. However, feel free not to merge it, I solve my own problem and it doesn't mean that it's the best way for everyone using it.