### PR TITLE
Allow for user definable deploy users

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Optionally, override the other slack settings:
     set :slack_run_starting,     -> { true }
     set :slack_run_finished,     -> { true }
     set :slack_run_failed,       -> { true }
-    set :slack_msg_starting,     -> { "#{ENV['USER'] || ENV['USERNAME']} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
-    set :slack_msg_finished,     -> { "#{ENV['USER'] || ENV['USERNAME']} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
-    set :slack_msg_failed,       -> { "#{ENV['USER'] || ENV['USERNAME']} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
+    set :slack_deploy_user,      -> { ENV['USER'] || ENV['USERNAME'] }
+    set :slack_msg_starting,     -> { "#{fetch :slack_deploy_user} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
+    set :slack_msg_finished,     -> { "#{fetch :slack_deploy_user} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
+    set :slack_msg_failed,       -> { "#{fetch :slack_deploy_user} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
     set :slack_title_starting,   -> { nil }
     set :slack_title_finished,   -> { nil }
     set :slack_title_failed,     -> { nil }

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -95,9 +95,10 @@ namespace :load do
     set :slack_run_starting,     -> { true } # Set to false to disable starting message.
     set :slack_run_finished,     -> { true } # Set to false to disable finished message.
     set :slack_run_failed,       -> { true } # Set to false to disable failure message.
-    set :slack_msg_starting,     -> { "#{ENV['USER'] || ENV['USERNAME']} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
-    set :slack_msg_finished,     -> { "#{ENV['USER'] || ENV['USERNAME']} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
-    set :slack_msg_failed,       -> { "#{ENV['USER'] || ENV['USERNAME']} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
+    set :slack_deploy_user,      -> { ENV['USER'] || ENV['USERNAME'] }
+    set :slack_msg_starting,     -> { "#{fetch :slack_deploy_user} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
+    set :slack_msg_finished,     -> { "#{fetch :slack_deploy_user} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
+    set :slack_msg_failed,       -> { "#{fetch :slack_deploy_user} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
     set :slack_title_starting,   -> { nil }
     set :slack_title_finished,   -> { nil }
     set :slack_title_failed,     -> { nil }


### PR DESCRIPTION
Given all the other things that can be set it seems reasonable that users should be able to define the deploy user.

The proposed set up maintains the existing option as the default but allows for an override