### PR TITLE
Bold branch name and stage name (if known) in default Slack messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Optionally, override the other slack settings:
     set :slack_run_finished,     -> { true }
     set :slack_run_failed,       -> { true }
     set :slack_deploy_user,      -> { ENV['USER'] || ENV['USERNAME'] }
-    set :slack_msg_starting,     -> { "#{fetch :slack_deploy_user} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
-    set :slack_msg_finished,     -> { "#{fetch :slack_deploy_user} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
-    set :slack_msg_failed,       -> { "#{fetch :slack_deploy_user} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
+    set :slack_msg_starting,     -> { "#{fetch :slack_deploy_user} has started deploying branch *#{fetch :branch}* of #{fetch :application} to #{"*#{fetch :stage}*" rescue 'an unknown stage'}" }
+    set :slack_msg_finished,     -> { "#{fetch :slack_deploy_user} has finished deploying branch *#{fetch :branch}* of #{fetch :application} to #{"*#{fetch :stage}*" rescue 'an unknown stage'}" }
+    set :slack_msg_failed,       -> { "#{fetch :slack_deploy_user} failed to deploy branch *#{fetch :branch}* of #{fetch :application} to #{"*#{fetch :stage}*" rescue 'an unknown stage'}" }
     set :slack_title_starting,   -> { nil }
     set :slack_title_finished,   -> { nil }
     set :slack_title_failed,     -> { nil }

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -96,9 +96,9 @@ namespace :load do
     set :slack_run_finished,     -> { true } # Set to false to disable finished message.
     set :slack_run_failed,       -> { true } # Set to false to disable failure message.
     set :slack_deploy_user,      -> { ENV['USER'] || ENV['USERNAME'] }
-    set :slack_msg_starting,     -> { "#{fetch :slack_deploy_user} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
-    set :slack_msg_finished,     -> { "#{fetch :slack_deploy_user} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
-    set :slack_msg_failed,       -> { "#{fetch :slack_deploy_user} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
+    set :slack_msg_starting,     -> { "#{fetch :slack_deploy_user} has started deploying branch *#{fetch :branch}* of #{fetch :application} to #{"*#{fetch :stage}*" rescue 'an unknown stage'}" }
+    set :slack_msg_finished,     -> { "#{fetch :slack_deploy_user} has finished deploying branch *#{fetch :branch}* of #{fetch :application} to #{"*#{fetch :stage}*" rescue 'an unknown stage'}" }
+    set :slack_msg_failed,       -> { "#{fetch :slack_deploy_user} failed to deploy branch *#{fetch :branch}* of #{fetch :application} to #{"*#{fetch :stage}*" rescue 'an unknown stage'}" }
     set :slack_title_starting,   -> { nil }
     set :slack_title_finished,   -> { nil }
     set :slack_title_failed,     -> { nil }


### PR DESCRIPTION
Hello 👻

I feel that it's important to highlight the most crucial pieces of information in the messages:

* Branch name
* Stage name

It would be strange to embolden an unknown branch though. I offer this solution as the shortest one. I understand that inline `rescue` is dirty. But there seems to be no potential harm it can do in this context. Nevertheless, please let me know if it needs rewriting.

Thank you.