### PR TITLE
Add slack:deploy:rollback task

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,24 +66,34 @@ set :slack_icon_emoji,        -> { nil } # will override icon_url, Must be a str
 set :slack_channel,           -> { nil } # Channel to post to. Optional. Defaults to WebHook setting. Required if using Slackbot.
 set :slack_channel_starting,  -> { nil } # Channel to post to. Optional. Defaults to :slack_channel.
 set :slack_channel_finished,  -> { nil } # Channel to post to. Optional. Defaults to :slack_channel.
+set :slack_channel_rollback,  -> { nil } # Channel to post to. Optional. Defaults to :slack_channel.
 set :slack_channel_failed,    -> { nil } # Channel to post to. Optional. Defaults to :slack_channel.
 set :slack_username,          -> { 'Slackistrano' }
 set :slack_run_starting,      -> { true }
 set :slack_run_finished,      -> { true }
+set :slack_run_rollback,      -> { true }
 set :slack_run_failed,        -> { true }
 set :slack_deploy_user,       -> { ENV['USER'] || ENV['USERNAME'] }
 set :slack_msg_starting,      -> { "#{fetch :slack_deploy_user} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
 set :slack_msg_finished,      -> { "#{fetch :slack_deploy_user} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
+set :slack_msg_rollback,      -> { "#{fetch :slack_deploy_user} has completed a rollback of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
 set :slack_msg_failed,        -> { "#{fetch :slack_deploy_user} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
 set :slack_fields_starting,   -> { [] }
 set :slack_fields_finished,   -> { [] }
+set :slack_fields_rollback,   -> { [] }
 set :slack_fields_failed,     -> { [] }
 set :slack_fallback_starting, -> { nil }
 set :slack_fallback_finished, -> { nil }
+set :slack_fallback_rollback, -> { nil }
 set :slack_fallback_failed,   -> { nil }
 set :slack_title_starting,    -> { nil }
 set :slack_title_finished,    -> { nil }
+set :slack_title_rollback,    -> { nil }
 set :slack_title_failed,      -> { nil }
+set :slack_pretext_starting,  -> { nil }
+set :slack_pretext_finished,  -> { nil }
+set :slack_pretext_rollback,  -> { nil }
+set :slack_pretext_failed,    -> { nil }
 ```
 
 **Note**: You may wish to disable one of the notifications if another service (ex:
@@ -94,6 +104,7 @@ Test your setup by running:
 ```bash
 $ cap production slack:deploy:starting
 $ cap production slack:deploy:finished
+$ cap production slack:deploy:rollback
 $ cap production slack:deploy:failed
 ```
 

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -52,6 +52,26 @@ namespace :slack do
       end
     end
 
+    task :rollback do
+      if fetch(:slack_run_rollback)
+        run_locally do
+          Slackistrano.post(
+            team: fetch(:slack_team),
+            token: fetch(:slack_token),
+            webhook: fetch(:slack_webhook),
+            via_slackbot: fetch(:slack_via_slackbot),
+            payload: {
+              channel: fetch(:slack_channel_rollback) || fetch(:slack_channel),
+              username: fetch(:slack_username),
+              icon_url: fetch(:slack_icon_url),
+              icon_emoji: fetch(:slack_icon_emoji),
+              attachments: make_attachments(:rollback, color: '#4CBDEC')
+            }
+          )
+        end
+      end
+    end
+
     task :failed do
       if fetch(:slack_run_failed)
         run_locally do
@@ -76,7 +96,8 @@ namespace :slack do
 end
 
 after 'deploy:starting', 'slack:deploy:starting'
-after 'deploy:finished', 'slack:deploy:finished'
+after 'deploy:finishing', 'slack:deploy:finished'
+after 'deploy:finishing_rollback', 'slack:deploy:rollback'
 after 'deploy:failed',   'slack:deploy:failed'
 
 namespace :load do
@@ -90,28 +111,35 @@ namespace :load do
     set :slack_channel,           -> { nil } # Channel to post to. Optional. Defaults to WebHook setting.
     set :slack_channel_starting,  -> { nil } # Channel to post to. Optional. Defaults to :slack_channel.
     set :slack_channel_finished,  -> { nil } # Channel to post to. Optional. Defaults to :slack_channel.
+    set :slack_channel_rollback,  -> { nil } # Channel to post to. Optional. Defaults to :slack_channel.
     set :slack_channel_failed,    -> { nil } # Channel to post to. Optional. Defaults to :slack_channel.
     set :slack_icon_url,          -> { 'http://gravatar.com/avatar/885e1c523b7975c4003de162d8ee8fee?r=g&s=40' }
     set :slack_icon_emoji,        -> { nil } # Emoji to use. Overrides icon_url. Must be a string (ex: ':shipit:')
     set :slack_username,          -> { 'Slackistrano' }
     set :slack_run_starting,      -> { true } # Set to false to disable starting message.
     set :slack_run_finished,      -> { true } # Set to false to disable finished message.
+    set :slack_run_rollback,      -> { true } # Set to false to disable rollback message.
     set :slack_run_failed,        -> { true } # Set to false to disable failure message.
     set :slack_deploy_user,       -> { ENV['USER'] || ENV['USERNAME'] }
     set :slack_msg_starting,      -> { "#{fetch :slack_deploy_user} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
     set :slack_msg_finished,      -> { "#{fetch :slack_deploy_user} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
+    set :slack_msg_rollback,      -> { "#{fetch :slack_deploy_user} has completed a rollback of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
     set :slack_msg_failed,        -> { "#{fetch :slack_deploy_user} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
     set :slack_fields_starting,   -> { [] }
     set :slack_fields_finished,   -> { [] }
+    set :slack_fields_rollback,   -> { [] }
     set :slack_fields_failed,     -> { [] }
     set :slack_fallback_starting, -> { nil }
     set :slack_fallback_finished, -> { nil }
+    set :slack_fallback_rollback, -> { nil }
     set :slack_fallback_failed,   -> { nil }
     set :slack_title_starting,    -> { nil }
     set :slack_title_finished,    -> { nil }
+    set :slack_title_rollback,    -> { nil }
     set :slack_title_failed,      -> { nil }
     set :slack_pretext_starting,  -> { nil }
     set :slack_pretext_finished,  -> { nil }
+    set :slack_pretext_rollback,  -> { nil }
     set :slack_pretext_failed,    -> { nil }
   end
 end

--- a/spec/capistrano_deploy_stubs.rake
+++ b/spec/capistrano_deploy_stubs.rake
@@ -1,7 +1,9 @@
 namespace :deploy do
   task :starting do
   end
-  task :finished do
+  task :finishing do
+  end
+  task :finishing_rollback do
   end
   task :failed do
   end

--- a/spec/tasks_spec.rb
+++ b/spec/tasks_spec.rb
@@ -18,7 +18,7 @@ describe Slackistrano do
   end
 
   it "invokes slack:deploy:rollback after deploy:finishing_rollback" do
-    set :slack_run_finished, ->{ true }
+    set :slack_run_rollback, ->{ true }
     expect(Slackistrano).to receive :post
     Rake::Task['deploy:finishing_rollback'].execute
   end

--- a/spec/tasks_spec.rb
+++ b/spec/tasks_spec.rb
@@ -11,10 +11,16 @@ describe Slackistrano do
     Rake::Task['deploy:starting'].execute
   end
 
-  it "invokes slack:deploy:finished after deploy:finished" do
+  it "invokes slack:deploy:finished after deploy:finishing" do
     set :slack_run_finished, ->{ true }
     expect(Slackistrano).to receive :post
-    Rake::Task['deploy:finished'].execute
+    Rake::Task['deploy:finishing'].execute
+  end
+
+  it "invokes slack:deploy:rollback after deploy:finishing_rollback" do
+    set :slack_run_finished, ->{ true }
+    expect(Slackistrano).to receive :post
+    Rake::Task['deploy:finishing_rollback'].execute
   end
 
   it "invokes slack:deploy:failed after deploy:failed" do
@@ -23,7 +29,7 @@ describe Slackistrano do
     Rake::Task['deploy:failed'].execute
   end
 
-  %w[starting finished failed].each do |stage|
+  %w[starting finished rollback failed].each do |stage|
     it "posts to slack on slack:deploy:#{stage}" do
       set "slack_run_#{stage}".to_sym, ->{ true }
       expect(Slackistrano).to receive :post
@@ -40,9 +46,11 @@ describe Slackistrano do
   [ # stage, color, channel
     ['starting', nil, nil],
     ['finished', 'good', nil],
+    ['rollback', '#4CBDEC', nil],
     ['failed', 'danger', nil],
     ['starting', nil, 'starting_channel'],
     ['finished', 'good', 'finished_channel'],
+    ['rollback', '#4CBDEC', 'rollback_channel'],
     ['failed', 'danger', 'failed_channel'],
   ].each do |stage, color, channel_for_stage|
 


### PR DESCRIPTION
This addresses issue #19. Here, we are adding a `slack:deploy:rollback` task that hooks into the Capistrano `deploy:finishing_rollback` task. This task includes all the same variables available to similar tasks like starting, finished, and failed.

Additionally, in order to differentiate between a deployment finishing and a rollback finishing, the `slack:deploy:finished` task was moved to the Capistrano `deploy:finishing` task.

Judging by the  difference between a [rollback](https://github.com/capistrano/capistrano/blob/44674031a626b3818fd248c788eab3145b60b19d/lib/capistrano/tasks/framework.rake#L52) and a [deploy](https://github.com/capistrano/capistrano/blob/44674031a626b3818fd248c788eab3145b60b19d/lib/capistrano/tasks/framework.rake#L64), using the `finishing` tasks seems more appropriate long term. 

@phallstrom Should this change agree with you, I suggest a `1.0` release to mark a major/API change (in case any users are depending on using `deploy:finished`). :green_heart: 