### PR TITLE
Allow posting to several channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ set :slack_channel_updated,    -> { nil } # Channel to post to. Defaults to :sla
 set :slack_channel_reverted,   -> { nil } # Channel to post to. Defaults to :slack_channel.
 set :slack_channel_failed,     -> { nil } # Channel to post to. Defaults to :slack_channel.
 
+# you can set :slack_channel or any of the :slack_channel variables to an array, and it slackistrano
+# will post to all the channels in the array:
+# set :slack_channel, %w[#general #deployments]
+
 set :slack_icon_url,           -> { 'http://gravatar.com/avatar/885e1c523b7975c4003de162d8ee8fee?r=g&s=40' }
 set :slack_icon_emoji,         -> { nil } # Emoji to use. Overrides icon_url. Must be a string (ex: ':shipit:')
 set :slack_username,           -> { 'Slackistrano' }

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -12,20 +12,22 @@ namespace :slack do
       [attachments]
     end
     
-    post_slackistrano = ->(channel, attachments) do
-      Slackistrano.post(
-        team: fetch(:slack_team),
-        token: fetch(:slack_token),
-        webhook: fetch(:slack_webhook),
-        via_slackbot: fetch(:slack_via_slackbot),
-        payload: {
-          channel: channel,
-          username: fetch(:slack_username),
-          icon_url: fetch(:slack_icon_url),
-          icon_emoji: fetch(:slack_icon_emoji),
-          attachments: attachments
-        }
-      )
+    post_slackistrano = ->(channels, attachments) do
+      Array(channels).each do |channel|
+        Slackistrano.post(
+          team: fetch(:slack_team),
+          token: fetch(:slack_token),
+          webhook: fetch(:slack_webhook),
+          via_slackbot: fetch(:slack_via_slackbot),
+          payload: {
+            channel: channel,
+            username: fetch(:slack_username),
+            icon_url: fetch(:slack_icon_url),
+            icon_emoji: fetch(:slack_icon_emoji),
+            attachments: attachments
+          }
+        )
+      end
     end
 
     task :updating do

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -11,24 +11,29 @@ namespace :slack do
       }).reject{|k, v| v.nil? }
       [attachments]
     end
+    
+    post_slackistrano = ->(channel, attachments) do
+      Slackistrano.post(
+        team: fetch(:slack_team),
+        token: fetch(:slack_token),
+        webhook: fetch(:slack_webhook),
+        via_slackbot: fetch(:slack_via_slackbot),
+        payload: {
+          channel: channel,
+          username: fetch(:slack_username),
+          icon_url: fetch(:slack_icon_url),
+          icon_emoji: fetch(:slack_icon_emoji),
+          attachments: attachments
+        }
+      )
+    end
 
     task :updating do
       set(:slack_deploy_or_rollback, 'deploy')
       if fetch(:slack_run_updating)
         run_locally do
-          Slackistrano.post(
-            team: fetch(:slack_team),
-            token: fetch(:slack_token),
-            webhook: fetch(:slack_webhook),
-            via_slackbot: fetch(:slack_via_slackbot),
-            payload: {
-              channel: fetch(:slack_channel_updating) || fetch(:slack_channel),
-              username: fetch(:slack_username),
-              icon_url: fetch(:slack_icon_url),
-              icon_emoji: fetch(:slack_icon_emoji),
-              attachments: make_attachments(:updating)
-            }
-          )
+          post_slackistrano.(fetch(:slack_channel_updating) || fetch(:slack_channel),
+                             make_attachments(:updating))
         end
       end
     end
@@ -37,19 +42,8 @@ namespace :slack do
       set(:slack_deploy_or_rollback, 'rollback')
       if fetch(:slack_run_reverting)
         run_locally do
-          Slackistrano.post(
-            team: fetch(:slack_team),
-            token: fetch(:slack_token),
-            webhook: fetch(:slack_webhook),
-            via_slackbot: fetch(:slack_via_slackbot),
-            payload: {
-              channel: fetch(:slack_channel_reverting) || fetch(:slack_channel),
-              username: fetch(:slack_username),
-              icon_url: fetch(:slack_icon_url),
-              icon_emoji: fetch(:slack_icon_emoji),
-              attachments: make_attachments(:reverting)
-            }
-          )
+          post_slackistrano.(fetch(:slack_channel_reverting) || fetch(:slack_channel),
+                             make_attachments(:reverting))
         end
       end
     end
@@ -58,19 +52,8 @@ namespace :slack do
     task :updated do
       if fetch(:slack_run_updated)
         run_locally do
-          Slackistrano.post(
-            team: fetch(:slack_team),
-            token: fetch(:slack_token),
-            webhook: fetch(:slack_webhook),
-            via_slackbot: fetch(:slack_via_slackbot),
-            payload: {
-              channel: fetch(:slack_channel_updated) || fetch(:slack_channel),
-              username: fetch(:slack_username),
-              icon_url: fetch(:slack_icon_url),
-              icon_emoji: fetch(:slack_icon_emoji),
-              attachments: make_attachments(:updated, color: 'good')
-            }
-          )
+          post_slackistrano.(fetch(:slack_channel_updated) || fetch(:slack_channel),
+                             make_attachments(:updated, color: 'good'))
         end
       end
     end
@@ -78,19 +61,8 @@ namespace :slack do
     task :reverted do
       if fetch(:slack_run_reverted)
         run_locally do
-          Slackistrano.post(
-            team: fetch(:slack_team),
-            token: fetch(:slack_token),
-            webhook: fetch(:slack_webhook),
-            via_slackbot: fetch(:slack_via_slackbot),
-            payload: {
-              channel: fetch(:slack_channel_reverted) || fetch(:slack_channel),
-              username: fetch(:slack_username),
-              icon_url: fetch(:slack_icon_url),
-              icon_emoji: fetch(:slack_icon_emoji),
-              attachments: make_attachments(:reverted, color: '#4CBDEC')
-            }
-          )
+          post_slackistrano.(fetch(:slack_channel_reverted) || fetch(:slack_channel),
+                             make_attachments(:reverted, color: '#4CBDEC'))
         end
       end
     end
@@ -98,19 +70,8 @@ namespace :slack do
     task :failed do
       if fetch(:slack_run_failed)
         run_locally do
-          Slackistrano.post(
-            team: fetch(:slack_team),
-            token: fetch(:slack_token),
-            webhook: fetch(:slack_webhook),
-            via_slackbot: fetch(:slack_via_slackbot),
-            payload: {
-              channel: fetch(:slack_channel_failed) || fetch(:slack_channel),
-              username: fetch(:slack_username),
-              icon_url: fetch(:slack_icon_url),
-              icon_emoji: fetch(:slack_icon_emoji),
-              attachments: make_attachments(:failed, color: 'danger')
-            }
-          )
+          post_slackistrano.(fetch(:slack_channel_failed) || fetch(:slack_channel),
+                             make_attachments(:failed, color: 'danger'))
         end
       end
     end


### PR DESCRIPTION
Allow posting to several channels by doing:

```ruby
set : slack_channel_updated, %w[#deploy #deploy-production]
```

Also significantly reduces code in all the tasks by using a lambda.
Haven't tried it locally, just edited it on github.