### PR TITLE
Add :slack_time_elapsed options

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ It will produce the following format:
 
 More information: [https://api.slack.com/docs/attachments](https://api.slack.com/docs/attachments)
 
+To add time elapsed to the `slack_fields_updated` an option can be set
+(not enabled per default):
+
+```
+set :slack_time_elapsed_enabled, true
+```
+
 ## Usage
 
 Deploy your application like normal and you should see messages in the channel

--- a/lib/slackistrano/capistrano.rb
+++ b/lib/slackistrano/capistrano.rb
@@ -116,6 +116,9 @@ module Slackistrano
         fallback:   fetch(:"slack_fallback_#{action}"),
         mrkdwn_in:  [:text, :pretext]
       }).reject{|k, v| v.nil? }
+      if fetch(:slack_time_elapsed_enabled) && action == :updated
+        attachments[:fields] << fetch(:slack_time_elapsed_field)
+      end
       [attachments]
     end
     private :make_attachments

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -94,5 +94,13 @@ namespace :load do
     set :slack_pretext_reverted,   -> { nil }
     set :slack_pretext_failed,     -> { nil }
 
+    set :slack_time_elapsed_enabled, false
+    set :slack_start_time,           Time.now
+    set :slack_time_elapsed, -> {
+      Time.now.to_i - fetch(:slack_start_time).to_i
+    }
+    set :slack_time_elapsed_field, -> {
+      { title: 'Time elapsed (sec)', value: fetch(:slack_time_elapsed) }
+    }
   end
 end


### PR DESCRIPTION
This allow to have elapsed time on the fields at the end of the deploy.

```
Time elapsed (sec)
103
```