### PR TITLE
Fix updated fields array example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,24 +146,24 @@ set :slack_msg_updated, nil
 set :slack_fallback_updated, "#{fetch(:slack_deploy_user)} deployed #{fetch(:application)} on #{fetch(:stage)}"
 set :slack_fields_updated, [
   {
-    "title": "Project",
-    "value": "<https://github.com/XXXXX/#{fetch(:application)}|#{fetch(:application)}>",
-    "short": true
+    "title" => "Project",
+    "value" => "<https://github.com/XXXXX/#{fetch(:application)}|#{fetch(:application)}>",
+    "short" => true
   },
   {
-    "title": "Environment",
-    "value": fetch(:stage),
-    "short": true
+    "title" => "Environment",
+    "value" => fetch(:stage),
+    "short" => true
   },
   {
-    "title": "Deployer",
-    "value": fetch(:slack_deploy_user),
-    "short": true
+    "title" => "Deployer",
+    "value" => fetch(:slack_deploy_user),
+    "short" => true
   },
   {
-    "title": "Revision",
-    "value": "<https://github.com/XXXXX/#{fetch(:application)}/commit/#{fetch(:slack_revision)}|#{fetch(:slack_revision)[0..6]}>",
-    "short": true
+    "title" => "Revision",
+    "value" => "<https://github.com/XXXXX/#{fetch(:application)}/commit/#{fetch(:slack_revision)}|#{fetch(:slack_revision)[0..6]}>",
+    "short" => true
   }
 ]
 ```


### PR DESCRIPTION
I got the following error with your actual example:

```bash
$ bundle exec cap production deploy
(Backtrace restricted to imported tasks)
cap aborted!
SyntaxError: config/deploy.rb:35: syntax error, unexpected ':', expecting =>
    "title": "Project",
            ^
config/deploy.rb:35: syntax error, unexpected ',', expecting end-of-input

Tasks: TOP => production
(See full trace by running task with --trace)
```