### PR TITLE
Catch up to changing Capistrano 3.5.0

### DIFF
--- a/lib/slackistrano/capistrano.rb
+++ b/lib/slackistrano/capistrano.rb
@@ -67,10 +67,7 @@ module Slackistrano
       channels.each do |channel|
         payload[:channel] = channel
 
-        # This is a nasty hack, but until Capistrano provides an official way to determine if
-        # --dry-run was passed this is the only option.
-        # See https://github.com/capistrano/capistrano/issues/1462
-        if ::Capistrano::Configuration.env.send(:config)[:sshkit_backend] == SSHKit::Backend::Printer
+        if ::Capistrano::Configuration.dry_run?
           backend.info("[slackistrano] Slackistrano Dry Run:")
           backend.info("[slackistrano]   Team: #{team}")
           backend.info("[slackistrano]   Webhook: #{webhook}")

--- a/spec/dry_run_spec.rb
+++ b/spec/dry_run_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Slackistrano do
   %w(updating reverting updated reverted failed).each do |stage|
     it "does not post to slack on slack:deploy:#{stage}" do
+      allow(Net::HTTP).to receive(:post_form).and_return double(code: '200')
       set "slack_run_#{stage}".to_sym, -> { true }
       expect(Slackistrano).not_to receive(:post)
       Rake::Task["slack:deploy:#{stage}"].execute

--- a/spec/dry_run_spec.rb
+++ b/spec/dry_run_spec.rb
@@ -8,7 +8,6 @@ describe Slackistrano do
   %w[updating reverting updated reverted failed].each do |stage|
     it "does not post to slack on slack:deploy:#{stage}" do
       set "slack_run_#{stage}".to_sym, ->{ true }
-      expect(Capistrano::Configuration.env.send(:config)).to receive(:[]).with(:sshkit_backend).and_return(SSHKit::Backend::Printer)
       expect(Slackistrano).not_to receive(:post)
       Rake::Task["slack:deploy:#{stage}"].execute
     end

--- a/spec/dry_run_spec.rb
+++ b/spec/dry_run_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Slackistrano do
-  before(:each) do
-    Rake::Task['load:defaults'].execute
-  end
-
   %w[updating reverting updated reverted failed].each do |stage|
     it "does not post to slack on slack:deploy:#{stage}" do
       set "slack_run_#{stage}".to_sym, ->{ true }

--- a/spec/dry_run_spec.rb
+++ b/spec/dry_run_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe Slackistrano do
-  %w[updating reverting updated reverted failed].each do |stage|
+  %w(updating reverting updated reverted failed).each do |stage|
     it "does not post to slack on slack:deploy:#{stage}" do
-      set "slack_run_#{stage}".to_sym, ->{ true }
+      set "slack_run_#{stage}".to_sym, -> { true }
       expect(Slackistrano).not_to receive(:post)
       Rake::Task["slack:deploy:#{stage}"].execute
     end
   end
-
 end


### PR DESCRIPTION
Capistrano 3.5.0 has many changes. 
- https://github.com/capistrano/capistrano/blob/master/CHANGELOG.md#350

In order to notify Slack using Slackistrano, I think that it is necessary to catch up with some changes.