### PR TITLE
Add task descriptions

### DIFF
--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -1,26 +1,32 @@
 namespace :slack do
   namespace :deploy do
 
+    desc 'Notify about updating deploy'
     task :updating do
       Slackistrano::Capistrano.new(self).run(:updating)
     end
 
+    desc 'Notify about reverting deploy'
     task :reverting do
       Slackistrano::Capistrano.new(self).run(:reverting)
     end
 
+    desc 'Notify about updated deploy'
     task :updated do
       Slackistrano::Capistrano.new(self).run(:updated)
     end
 
+    desc 'Notify about reverted deploy'
     task :reverted do
       Slackistrano::Capistrano.new(self).run(:reverted)
     end
 
+    desc 'Notify about failed deploy'
     task :failed do
       Slackistrano::Capistrano.new(self).run(:failed)
     end
 
+    desc 'Test Slack integration'
     task :test => %i[updating updated reverting reverted failed] do
       # all tasks run as dependencies
     end


### PR DESCRIPTION
Hi @phallstrom,

thank you for the very nice gem!

I installed it and I wanted to know which tasks it gives me (with `cap -T`).
But I saw nothing. It seems like it's because of tasks have no descriptions.

So I added some very basic text and now `cap -T` outputs
```
...
cap slack:deploy:failed            # Notify about failed deploy
cap slack:deploy:reverted          # Notify about reverted deploy
cap slack:deploy:reverting         # Notify about reverting deploy
cap slack:deploy:test              # Test Slack integration
cap slack:deploy:updated           # Notify about updated deploy
cap slack:deploy:updating          # Notify about updating deploy
...
```