### PR TITLE
Disable posting to slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ To set this up:
    an issue along with a screenshot of the output from `cap production
    slack:deploy:test` and I'll add it to the Wiki.
 
+## Disabling posting to Slack
+
+You can disable deployment notifactions to a specific stage by setting the `:slackistrano` 
+configuration variable to `false` instead of actual settings.
+
+```ruby
+set :slackistrano, :disabled
+```
+
 ## TODO
 
 - Notify about incorrect configuration settings.

--- a/lib/slackistrano/capistrano.rb
+++ b/lib/slackistrano/capistrano.rb
@@ -16,8 +16,8 @@ module Slackistrano
 
     def initialize(env)
       @env = env
-      opts = fetch(:slackistrano, {}).dup
-      @messaging = case opts
+      config = fetch(:slackistrano, {})
+      @messaging = case config
                    when false
                      Messaging::Null.new
                    when -> (o) { o.empty? }
@@ -29,8 +29,9 @@ module Slackistrano
                        webhook: fetch(:slack_webhook)
                      )
                    else
+                     opts = config.dup.merge(env: @env)
                      klass = opts.delete(:klass) || Messaging::Default
-                     klass.new(opts.merge(env: @env))
+                     klass.new(opts)
                    end
     end
 

--- a/lib/slackistrano/capistrano.rb
+++ b/lib/slackistrano/capistrano.rb
@@ -17,7 +17,10 @@ module Slackistrano
     def initialize(env)
       @env = env
       opts = fetch(:slackistrano, {}).dup
-      @messaging = if opts.empty?
+      @messaging = case opts
+                   when false
+                     Messaging::Null.new
+                   when -> (o) { o.empty? }
                      klass = Messaging::Deprecated.new(
                        env: @env,
                        team: fetch(:slack_team),

--- a/lib/slackistrano/messaging/base.rb
+++ b/lib/slackistrano/messaging/base.rb
@@ -71,3 +71,4 @@ end
 
 require_relative 'default'
 require_relative 'deprecated'
+require_relative 'null'

--- a/lib/slackistrano/messaging/null.rb
+++ b/lib/slackistrano/messaging/null.rb
@@ -1,0 +1,25 @@
+module Slackistrano
+  module Messaging
+    class Null < Base
+      def payload_for_updating
+        nil
+      end
+
+      def payload_for_reverting
+        nil
+      end
+
+      def payload_for_updated
+        nil
+      end
+
+      def payload_for_reverted
+        nil
+      end
+
+      def payload_for_failed
+        nil
+      end
+    end
+  end
+end

--- a/spec/disabling_posting_to_slack_spec.rb
+++ b/spec/disabling_posting_to_slack_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Slackistrano do
+  context "when :slackistrano is :disabled" do
+    before(:all) do
+      set :slackistrano, false
+    end
+    
+    %w[updating reverting updated reverted failed].each do |stage|
+      it "doesn't post on slack:deploy:#{stage}" do
+        expect_any_instance_of(Slackistrano::Capistrano).not_to receive(:post)
+        Rake::Task["slack:deploy:#{stage}"].execute
+      end
+    end
+  end
+end

--- a/spec/messaging/null_spec.rb
+++ b/spec/messaging/null_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Slackistrano::Messaging::Null do
+  subject(:messaging) { Slackistrano::Messaging::Null.new }
+  
+  %w[updating reverting updated reverted failed].each do |stage|
+    it "returns no payload for on #{stage}" do
+      expect(messaging.payload_for(stage)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
I missed the ability to disable posting to Slack that was introduced in 6ec4bbe in response to #35. This PR brings it back, by letting a user set `:slackistrano`  to  `false`.