### PR TITLE
Add defined? guard and better custom exemple

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,78 +86,82 @@ You can customize the messaging posted to Slack by providing your own messaging
 class and overriding several methods. Here is one example:
 
 ```ruby
-module Slackistrano
-  class CustomMessaging < Messaging::Base
+if defined?(Slackistrano::Messaging)
+   module Slackistrano
+     class CustomMessaging < Messaging::Base
 
-    # Send failed message to #ops. Send all other messages to default channels.
-    # The #ops channel must exist prior.
-    def channels_for(action)
-      if action == :failed
-        "#ops"
-      else
-        super
-      end
-    end
+       # Send failed message to #ops. Send all other messages to default channels.
+       # The #ops channel must exist prior.
+       def channels_for(action)
+         if action == :failed
+           "#ops"
+         else
+           super
+         end
+       end
 
-    # Suppress updating message.
-    def payload_for_updating
-      nil
-    end
+       # Suppress updating message.
+       def payload_for_updating
+         nil
+       end
 
-    # Suppress reverting message.
-    def payload_for_reverting
-      nil
-    end
+       # Suppress reverting message.
+       def payload_for_reverting
+         nil
+       end
 
-    # Fancy updated message.
-    # See https://api.slack.com/docs/message-attachments
-    def payload_for_updated
-      {
-        attachments: [{
-          color: 'good',
-          title: 'Integrations Application Deployed :boom::bangbang:',
-          fields: [{
-            title: 'Environment',
-            value: stage,
-            short: true
-          }, {
-            title: 'Branch',
-            value: branch,
-            short: true
-          }, {
-            title: 'Deployer',
-            value: deployer,
-            short: true
-          }, {
-            title: 'Time',
-            value: elapsed_time,
-            short: true
-          }],
-          fallback: super[:text]
-        }]
-      }
-    end
+       # Fancy updated message.
+       # See https://api.slack.com/docs/message-attachments
+       def payload_for_updated
+         {
+           attachments: [{
+             color: 'good',
+             title: 'Integrations Application Deployed :boom::bangbang:',
+             fields: [{
+               title: 'Environment',
+               value: stage,
+               short: true
+             }, {
+               title: 'Branch',
+               value: branch,
+               short: true
+             }, {
+               title: 'Deployer',
+               value: deployer,
+               short: true
+             }, {
+               title: 'Time',
+               value: elapsed_time,
+               short: true
+             }],
+             fallback: super[:text]
+           }]
+         }
+       end
 
-    # Default reverted message.  Alternatively simply do not redefine this
-    # method.
-    def payload_for_reverted
-      super
-    end
+       # Default reverted message.  Alternatively simply do not redefine this
+       # method.
+       def payload_for_reverted
+         super
+       end
 
-    # Slightly tweaked failed message.
-    # See https://api.slack.com/docs/message-formatting
-    def payload_for_failed
-      payload = super
-      payload[:text] = "OMG :fire: #{payload[:text]}"
-      payload
-    end
+       # Slightly tweaked failed message.
+       # See https://api.slack.com/docs/message-formatting
+       def payload_for_failed
+         payload = super
+         payload[:text] = "OMG :fire: #{payload[:text]}"
+         payload
+       end
 
-    # Override the deployer helper to pull the full name from the password file.
-    # See https://github.com/phallstrom/slackistrano/blob/master/lib/slackistrano/messaging/helpers.rb
-    def deployer
-      Etc.getpwnam(ENV['USER']).gecos
-    end
-  end
+       # Override the deployer helper to pull the full name from the password file.
+       # See https://github.com/phallstrom/slackistrano/blob/master/lib/slackistrano/messaging/helpers.rb
+       def deployer
+         name = `git config user.name`.strip
+         name = ENV['USER'] || ENV['USERNAME'] if name.nil? || name.empty?
+         name
+       end
+     end
+   end
 end
 ```
 


### PR DESCRIPTION
We had some problems with the custom class overwrite because Capistrano and Slackistrano are only in the Gemfile `development` group, and since the file is in `lib/`, rails was trying to load it, leading to `uninitialized constant Slackistrano::Messaging`

I also added an exemple to use the git user full name, which is cleaner in my opinion (still falling back to the user ENV).