### PR TITLE
add the ability to customize icon_url, icon_emoji, and username

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ You have two options to notify a channel in Slack when you deploy:
    }
    ```
 
+### Optional Configuration & Overrides
+
+By default Slackistrano will use a default icon and username. These, can be
+overriden if you are using the default messaging class (ie. have not specified
+your own).
+
+1. Configure per instructions above.
+2. Add the following to `config/deploy.rb`:
+
+   ```ruby
+   set :slackistrano, {
+    ...
+    username: 'Foobar the Deployer',
+    icon_emoji: ':thumbsup:', # takes precedence over icon_url
+    icon_url: 'https://avatars2.githubusercontent.com/u/16705?v=4&s=40',
+    ...
+   }
+   ```
+
+
 ### Test your Configuration
 
 Test your setup by running the following command. This will post each stage's

--- a/lib/slackistrano/messaging/base.rb
+++ b/lib/slackistrano/messaging/base.rb
@@ -10,14 +10,16 @@ module Slackistrano
       extend Forwardable
       def_delegators :env, :fetch
 
-      attr_reader :team, :token, :webhook
+      attr_reader :team, :token, :webhook, :options
 
-      def initialize(env: nil, team: nil, channel: nil, token: nil, webhook: nil)
-        @env = env
-        @team = team
-        @channel = channel
-        @token = token
-        @webhook = webhook
+      def initialize(options = {})
+        @options = options.dup
+
+        @env = options.delete(:env)
+        @team = options.delete(:team)
+        @channel = options.delete(:channel)
+        @token = options.delete(:token)
+        @webhook = options.delete(:webhook)
       end
 
       def payload_for_updating

--- a/lib/slackistrano/messaging/helpers.rb
+++ b/lib/slackistrano/messaging/helpers.rb
@@ -3,15 +3,15 @@ module Slackistrano
     module Helpers
 
       def icon_url
-        'https://raw.githubusercontent.com/phallstrom/slackistrano/master/images/slackistrano.png'
+        options.fetch(:icon_url, 'https://raw.githubusercontent.com/phallstrom/slackistrano/master/images/slackistrano.png')
       end
 
       def icon_emoji
-        nil
+        options.fetch(:icon_emoji, nil)
       end
 
       def username
-        'Slackistrano'
+        options.fetch(:username, 'Slackistrano')
       end
 
       def deployer

--- a/spec/messaging/helpers_spec.rb
+++ b/spec/messaging/helpers_spec.rb
@@ -2,6 +2,39 @@ require 'spec_helper'
 
 describe Slackistrano::Messaging::Default do
 
+  describe "#icon_url" do
+    it "returns a default" do
+      expect(subject.icon_url).to match(/phallstrom.*slackistrano.png/)
+    end
+
+    it "returns a custom option" do
+      allow(subject).to receive(:options).and_return(icon_url: 'http://example.com/foo.png')
+      expect(subject.icon_url).to eq 'http://example.com/foo.png'
+    end
+  end
+
+  describe "#icon_emoji" do
+    it "returns a default of nil" do
+      expect(subject.icon_emoji).to eq nil
+    end
+
+    it "returns a custom option" do
+      allow(subject).to receive(:options).and_return(icon_emoji: ':thumbsup:')
+      expect(subject.icon_emoji).to eq ':thumbsup:'
+    end
+  end
+
+  describe "#username" do
+    it "returns a default" do
+      expect(subject.username).to eq 'Slackistrano'
+    end
+
+    it "returns a custom option" do
+      allow(subject).to receive(:options).and_return(username: 'Codan the Deployer')
+      expect(subject.username).to eq 'Codan the Deployer'
+    end
+  end
+
   describe '#branch' do
     it "delegates to fetch" do
       expect(subject).to receive(:fetch).with(:branch)


### PR DESCRIPTION
This adds the ability to easily set your own icon_url, icon_emoji, and
username, overriding the defaults without needing to specify your own
custom messaging class.

see #68 (tldr; @hajder was right)