### PR TITLE
Default deployer name to local_user capistrano config value

### DIFF
--- a/lib/slackistrano/messaging/helpers.rb
+++ b/lib/slackistrano/messaging/helpers.rb
@@ -15,7 +15,8 @@ module Slackistrano
       end
 
       def deployer
-        ENV['USER'] || ENV['USERNAME']
+        default = ENV['USER'] || ENV['USERNAME']
+        fetch(:local_user, default)
       end
 
       def branch

--- a/spec/messaging/helpers_spec.rb
+++ b/spec/messaging/helpers_spec.rb
@@ -35,6 +35,18 @@ describe Slackistrano::Messaging::Default do
     end
   end
 
+  describe '#deployer' do
+    it "delegates to fetch" do
+      expect(subject).to receive(:fetch).with(:local_user, anything)
+      subject.deployer
+    end
+
+    it "has a default" do
+      ENV['USER'] = 'cappy'
+      expect(subject.deployer).to eq 'cappy'
+    end
+  end
+
   describe '#branch' do
     it "delegates to fetch" do
       expect(subject).to receive(:fetch).with(:branch)


### PR DESCRIPTION
Had issue where when using gitlab CI, neither USER nor USERNAME persists into the slackistrano code. Capistrano already provides a local_user config for this, so am making it use that, and fall back to what it was before.