### PR TITLE
Send a message on starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Slackistrano Change Log
 
+3.9.0
+-----
+
+- **BREAKING:** Send starting message on `starting` process instead of `updating`
+
 3.8.3
 -----
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ if defined?(Slackistrano::Messaging)
          end
        end
 
-       # Suppress updating message.
-       def payload_for_updating
+       # Suppress starting message.
+       def payload_for_starting
          nil
        end
 

--- a/lib/slackistrano/messaging/base.rb
+++ b/lib/slackistrano/messaging/base.rb
@@ -22,7 +22,7 @@ module Slackistrano
         @webhook = options.delete(:webhook)
       end
 
-      def payload_for_updating
+      def payload_for_starting
         {
           text: "#{deployer} has started deploying branch #{branch} of #{application} to #{stage}"
         }

--- a/lib/slackistrano/messaging/default.rb
+++ b/lib/slackistrano/messaging/default.rb
@@ -2,7 +2,7 @@ module Slackistrano
   module Messaging
     class Default < Base
 
-      def payload_for_updating
+      def payload_for_starting
         super
       end
 

--- a/lib/slackistrano/messaging/deprecated.rb
+++ b/lib/slackistrano/messaging/deprecated.rb
@@ -31,7 +31,7 @@ module Slackistrano
         fetch("slack_channel_#{action}".to_sym) || super
       end
 
-      def payload_for_updating
+      def payload_for_starting
         make_message(__method__, super)
       end
 

--- a/lib/slackistrano/messaging/null.rb
+++ b/lib/slackistrano/messaging/null.rb
@@ -1,7 +1,7 @@
 module Slackistrano
   module Messaging
     class Null < Base
-      def payload_for_updating
+      def payload_for_starting
         nil
       end
 

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -1,9 +1,9 @@
 namespace :slack do
   namespace :deploy do
 
-    desc 'Notify about updating deploy'
-    task :updating do
-      Slackistrano::Capistrano.new(self).run(:updating)
+    desc 'Notify about starting deploy'
+    task :starting do
+      Slackistrano::Capistrano.new(self).run(:starting)
     end
 
     desc 'Notify about reverting deploy'
@@ -27,14 +27,14 @@ namespace :slack do
     end
 
     desc 'Test Slack integration'
-    task :test => %i[updating updated reverting reverted failed] do
+    task :test => %i[starting updated reverting reverted failed] do
       # all tasks run as dependencies
     end
 
   end
 end
 
-before 'deploy:updating',           'slack:deploy:updating'
+before 'deploy:starting',           'slack:deploy:starting'
 before 'deploy:reverting',          'slack:deploy:reverting'
 after  'deploy:finishing',          'slack:deploy:updated'
 after  'deploy:finishing_rollback', 'slack:deploy:reverted'

--- a/lib/slackistrano/version.rb
+++ b/lib/slackistrano/version.rb
@@ -1,3 +1,3 @@
 module Slackistrano
-  VERSION = '3.8.4'
+  VERSION = '3.9.0'
 end

--- a/slackistrano.gemspec
+++ b/slackistrano.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'capistrano', '>= 3.9.0'
+  gem.add_dependency 'capistrano', '>= 3.8.1'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'pry'

--- a/slackistrano.gemspec
+++ b/slackistrano.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'capistrano', '>= 3.8.1'
+  gem.add_dependency 'capistrano', '>= 3.9.0'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'pry'

--- a/spec/capistrano_deploy_stubs.rake
+++ b/spec/capistrano_deploy_stubs.rake
@@ -1,5 +1,5 @@
 namespace :deploy do
-  task :updating do
+  task :starting do
   end
   task :reverting do
   end

--- a/spec/disabling_posting_to_slack_spec.rb
+++ b/spec/disabling_posting_to_slack_spec.rb
@@ -5,8 +5,8 @@ describe Slackistrano do
     before(:all) do
       set :slackistrano, false
     end
-    
-    %w[updating reverting updated reverted failed].each do |stage|
+
+    %w[starting reverting updated reverted failed].each do |stage|
       it "doesn't post on slack:deploy:#{stage}" do
         expect_any_instance_of(Slackistrano::Capistrano).not_to receive(:post)
         Rake::Task["slack:deploy:#{stage}"].execute

--- a/spec/dry_run_spec.rb
+++ b/spec/dry_run_spec.rb
@@ -11,7 +11,7 @@ describe Slackistrano do
     set :slackistrano, { klass: DryRunMessaging }
   end
 
-  %w[updating reverting updated reverted failed].each do |stage|
+  %w[starting reverting updated reverted failed].each do |stage|
     it "does not post to slack on slack:deploy:#{stage}" do
       allow_any_instance_of(Slackistrano::Capistrano).to receive(:dry_run?).and_return(true)
       expect_any_instance_of(Slackistrano::Capistrano).to receive(:post_dry_run)

--- a/spec/messaging/deprecated_spec.rb
+++ b/spec/messaging/deprecated_spec.rb
@@ -5,7 +5,7 @@ describe Slackistrano::Messaging::Deprecated do
     set :slackistrano, {}
   end
 
-  %w[updating reverting updated reverted failed].each do |stage|
+  %w[starting reverting updated reverted failed].each do |stage|
     it "posts to slack on slack:deploy:#{stage}" do
       set :slack_webhook, -> { "..." }
       set :slack_run, ->{ true }
@@ -32,12 +32,12 @@ describe Slackistrano::Messaging::Deprecated do
   end
 
   [ # stage, color, channel
-    ['updating', nil, nil],
+    ['starting', nil, nil],
     ['reverting', nil, nil],
     ['updated', 'good', nil],
     ['reverted', 'warning', nil],
     ['failed', 'danger', nil],
-    ['updating', nil, 'starting_channel'],
+    ['starting', nil, 'starting_channel'],
     ['updated', 'good', 'finished_channel'],
     ['reverted', 'warning', 'rollback_channel'],
     ['failed', 'danger', 'failed_channel'],

--- a/spec/messaging/null_spec.rb
+++ b/spec/messaging/null_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe Slackistrano::Messaging::Null do
   subject(:messaging) { Slackistrano::Messaging::Null.new }
-  
-  %w[updating reverting updated reverted failed].each do |stage|
+
+  %w[starting reverting updated reverted failed].each do |stage|
     it "returns no payload for on #{stage}" do
       expect(messaging.payload_for(stage)).to be_nil
     end

--- a/spec/nil_payload_spec.rb
+++ b/spec/nil_payload_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 class NilPayloadMessaging < Slackistrano::Messaging::Default
-  def payload_for_updating
+  def payload_for_starting
     nil
   end
 
@@ -15,9 +15,9 @@ describe Slackistrano do
     set :slackistrano, { klass: NilPayloadMessaging }
   end
 
-  it "does not post on updating" do
+  it "does not post on starting" do
     expect_any_instance_of(Slackistrano::Capistrano).not_to receive(:post)
-    Rake::Task["slack:deploy:updating"].execute
+    Rake::Task["slack:deploy:starting"].execute
   end
 
   it "posts on updated" do

--- a/spec/posting_to_multiple_channels_spec.rb
+++ b/spec/posting_to_multiple_channels_spec.rb
@@ -8,7 +8,7 @@ describe Slackistrano do
   end
 
   context "when :slack_channel is an array" do
-    %w[updating reverting updated reverted failed].each do |stage|
+    %w[starting reverting updated reverted failed].each do |stage|
       it "posts to slack on slack:deploy:#{stage} in every channel" do
         expect_any_instance_of(Slackistrano::Capistrano).to receive(:post).twice
         Rake::Task["slack:deploy:#{stage}"].execute

--- a/spec/task_hooks_spec.rb
+++ b/spec/task_hooks_spec.rb
@@ -4,8 +4,8 @@ describe Slackistrano do
 
   describe "before/after hooks" do
 
-    it "invokes slack:deploy:updating before deploy:updating" do
-      expect(Rake::Task['deploy:updating'].prerequisites).to include 'slack:deploy:updating'
+    it "invokes slack:deploy:starting before deploy:starting" do
+      expect(Rake::Task['deploy:starting'].prerequisites).to include 'slack:deploy:starting'
     end
 
     it "invokes slack:deploy:reverting before deploy:reverting" do
@@ -28,7 +28,7 @@ describe Slackistrano do
     end
 
     it "invokes all slack:deploy tasks before slack:deploy:test" do
-      expect(Rake::Task['slack:deploy:test'].prerequisites).to match %w[updating updated reverting reverted failed]
+      expect(Rake::Task['slack:deploy:test'].prerequisites).to match %w[starting updated reverting reverted failed]
     end
   end
 


### PR DESCRIPTION
It's better to send a message to a slack channel on starting instead of updating.
Starting is the [first part](https://github.com/capistrano/capistrano/blob/master/lib/capistrano/tasks/deploy.rake#L2) of the deploying process.

I'll try to explain the changes.
We have many developers and we don't want to conflict on deploy. First steps in our process deployment are:
 - Send [TSTP](https://github.com/mperham/sidekiq/wiki/Signals#tstp) signal to sidekick-server
 - Graceful shutdown for other services

This causes to us delay for **1.5 minutes** before starting deploy in the console and the message in the channel.