### PR TITLE
Add dependency on openssl >= 3.3.1 to gemspec

### DIFF
--- a/slackistrano.gemspec
+++ b/slackistrano.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'capistrano', '>= 3.8.1'
+  gem.add_dependency 'openssl', '>= 3.3.1'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'pry'


### PR DESCRIPTION
I've been running into ssl issues recently.

```shell
…
cap aborted!
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 peeraddr=35.186.247.156:443 state=error: certificate verify failed (unable to get certificate CRL) (OpenSSL::SSL::SSLError)

Tasks: TOP => sentry:notice_deployment
(See full trace by running task with --trace)
The deploy has failed with an error: SSL_connect returned=1 errno=0 peeraddr=35.186.247.156:443 state=error: certificate verify failed (unable to get certificate CRL)
```

---

I'm using openssl with version `3.6.0`.

```
openssl --version
OpenSSL 3.6.0 1 Oct 2025 (Library: OpenSSL 3.6.0 1 Oct 2025)
```

---

I've found this GitHub [issue](https://github.com/ruby/openssl/issues/949) which lead me to the idea that this could help solve the aforementioned problem and it did.

---

I haven't taken the time yet to fully understand my proposed change, so I'll have to leave this often as a draft (for now) and come back later to dig into the issue to provide more context.